### PR TITLE
feature/fonts-support-in-linux

### DIFF
--- a/pptx/text/fonts.py
+++ b/pptx/text/fonts.py
@@ -54,6 +54,8 @@ class FontFiles(object):
             return cls._os_x_font_directories()
         if sys.platform.startswith("win32"):
             return cls._windows_font_directories()
+        if sys.platform.startswith("linux"):
+            return cls._linux_font_directories()
         raise OSError("unsupported operating system")
 
     @classmethod
@@ -98,6 +100,24 @@ class FontFiles(object):
         likely to be located.
         """
         return [r"C:\Windows\Fonts"]
+
+    @classmethod
+    def _linux_font_directories(cls):
+        """
+        Return a sequence of directory paths on Linux in which fonts are
+        likely to be located.
+        """
+        linux_font_dirs = [
+            "/usr/share/fonts",
+            "/usr/local/share/fonts",
+        ]
+        home = os.environ.get("HOME")
+        if home is not None:
+            linux_font_dirs.extend([
+                os.path.join(home, ".fonts"),
+                os.path.join(home, ".local/share/fonts"),
+            ])
+        return linux_font_dirs
 
 
 class _Font(object):

--- a/tests/text/test_fonts.py
+++ b/tests/text/test_fonts.py
@@ -63,6 +63,11 @@ class DescribeFontFiles(object):
         font_dirs = FontFiles._windows_font_directories()
         assert font_dirs == expected_dirs
 
+    def it_knows_linux_font_dirs_to_help_find(self, linux_dirs_fixture):
+        expected_dirs = linux_dirs_fixture
+        font_dirs = FontFiles._linux_font_directories()
+        assert font_dirs == expected_dirs
+
     def it_iterates_over_fonts_in_dir_to_help_find(self, iter_fixture):
         directory, _Font_, expected_calls, expected_paths = iter_fixture
         paths = list(FontFiles._iter_font_files_in(directory))
@@ -85,14 +90,19 @@ class DescribeFontFiles(object):
         family_name, is_bold, is_italic, expected_path = request.param
         return family_name, is_bold, is_italic, expected_path
 
-    @pytest.fixture(params=[("darwin", ["a", "b"]), ("win32", ["c", "d"])])
+    @pytest.fixture(params=[
+        ("darwin", ["a", "b"]),
+        ("win32", ["c", "d"]),
+        ("linux", ["e", "f"]),
+    ])
     def font_dirs_fixture(
-        self, request, _os_x_font_directories_, _windows_font_directories_
+        self, request, _os_x_font_directories_, _windows_font_directories_, _linux_font_directories_
     ):
         platform, expected_dirs = request.param
         dirs_meth_mock = {
             "darwin": _os_x_font_directories_,
             "win32": _windows_font_directories_,
+            "linux": _linux_font_directories_,
         }[platform]
         sys_ = var_mock(request, "pptx.text.fonts.sys")
         sys_.platform = platform
@@ -139,6 +149,19 @@ class DescribeFontFiles(object):
     def win_dirs_fixture(self, request):
         return [r"C:\Windows\Fonts"]
 
+    @pytest.fixture
+    def linux_dirs_fixture(self, request):
+        import os
+        os_ = var_mock(request, "pptx.text.fonts.os")
+        os_.path = os.path
+        os_.environ = {"HOME": "/home/fbar"}
+        return [
+            "/usr/share/fonts",
+            "/usr/local/share/fonts",
+            "/home/fbar/.fonts",
+            "/home/fbar/.local/share/fonts",
+        ]
+
     # fixture components -----------------------------------
 
     @pytest.fixture
@@ -170,6 +193,10 @@ class DescribeFontFiles(object):
     @pytest.fixture
     def _windows_font_directories_(self, request):
         return method_mock(request, FontFiles, "_windows_font_directories")
+
+    @pytest.fixture
+    def _linux_font_directories_(self, request):
+        return method_mock(request, FontFiles, '_linux_font_directories')
 
 
 class Describe_Font(object):


### PR DESCRIPTION
This PR adds the ability to read fonts from the following paths in linux systems:
`/usr/share/fonts`
`/usr/local/share/fonts`

and, if `$HOME` is configured:
`$HOME/.fonts`
`$HOME/.local/share/fonts`

Necessary for deployment of slider on Centos7.